### PR TITLE
Stripe compliance: contact info, refund policy visibility (#334, #335)

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,7 +338,7 @@
         }
         @media (min-width: 768px) {
             .footer { padding: 3rem 1.5rem; }
-            .footer-grid { grid-template-columns: 2fr 1fr 1fr 1fr; }
+            .footer-grid { grid-template-columns: 2fr 1fr 1fr 1fr 1fr; }
             .footer-brand { grid-column: auto; margin-bottom: 0; }
             .footer-brand .logo span { font-size: 1.125rem; }
             .footer-brand p { font-size: 0.875rem; }
@@ -646,6 +646,11 @@
                     <a href="mailto:hello@toolguard.ai" class="card-btn outline">Contact Sales</a>
                 </div>
             </div>
+            <p style="text-align:center;margin-top:2rem;font-size:0.8125rem;color:#6b7280;">
+                All prices in USD. Annual plans refundable within 30 days. Monthly plans are non-refundable. Cancel anytime — no fees.
+                <a href="/terms.html#cancellation" style="color:var(--brand-600);text-decoration:underline;">See full refund &amp; cancellation policy</a> ·
+                Questions? <a href="mailto:support@toolguard.ai" style="color:var(--brand-600);">support@toolguard.ai</a>
+            </p>
         </div>
     </section>
 
@@ -718,14 +723,21 @@
                     <h4>Company</h4>
                     <ul>
                         <li><a href="#">About</a></li>
-                        <li><a href="mailto:hello@toolguard.ai">Contact</a></li>
                         <li><a href="/privacy.html">Privacy Policy</a></li>
                         <li><a href="/terms.html">Terms of Service</a></li>
                     </ul>
                 </div>
+                <div>
+                    <h4>Support</h4>
+                    <ul>
+                        <li><a href="mailto:support@toolguard.ai">support@toolguard.ai</a></li>
+                        <li><a href="/terms.html#cancellation">Refund Policy</a></li>
+                        <li><a href="/terms.html#cancellation">Cancellation Policy</a></li>
+                    </ul>
+                </div>
             </div>
             <hr>
-            <p class="copyright">&copy; 2026 Elixie, LLC. All rights reserved. ToolGuard is a product of Elixie, LLC.</p>
+            <p class="copyright">&copy; 2026 Elixie, LLC &mdash; California, USA &mdash; All rights reserved. ToolGuard is a product of Elixie, LLC.</p>
         </div>
     </footer>
 

--- a/pricing.html
+++ b/pricing.html
@@ -255,7 +255,7 @@
         }
         @media (min-width: 768px) {
             .footer { padding: 3rem 1.5rem; }
-            .footer-grid { grid-template-columns: 2fr 1fr 1fr 1fr; }
+            .footer-grid { grid-template-columns: 2fr 1fr 1fr 1fr 1fr; }
             .footer-brand { grid-column: auto; margin-bottom: 0; }
             .footer-brand .logo span { font-size: 1.125rem; }
             .footer-brand p { font-size: 0.875rem; }
@@ -435,6 +435,14 @@
                 </div>
 
             </div>
+            <p style="text-align:center;margin-top:2.5rem;font-size:0.8125rem;color:#6b7280;line-height:1.7;">
+                All prices in USD &nbsp;·&nbsp;
+                Annual plans can be refunded on a prorated basis within 30 days. Monthly plans are non-refundable. Cancel anytime — no fees.
+                <br>
+                <a href="/terms.html#cancellation" style="color:var(--brand-600);text-decoration:underline;">Full refund &amp; cancellation policy</a>
+                &nbsp;·&nbsp;
+                Questions? <a href="mailto:support@toolguard.ai" style="color:var(--brand-600);">support@toolguard.ai</a>
+            </p>
         </div>
     </section>
 
@@ -533,14 +541,21 @@
                     <h4>Company</h4>
                     <ul>
                         <li><a href="#">About</a></li>
-                        <li><a href="mailto:support@toolguard.ai">Contact</a></li>
                         <li><a href="/privacy.html">Privacy Policy</a></li>
                         <li><a href="/terms.html">Terms of Service</a></li>
                     </ul>
                 </div>
+                <div>
+                    <h4>Support</h4>
+                    <ul>
+                        <li><a href="mailto:support@toolguard.ai">support@toolguard.ai</a></li>
+                        <li><a href="/terms.html#cancellation">Refund Policy</a></li>
+                        <li><a href="/terms.html#cancellation">Cancellation Policy</a></li>
+                    </ul>
+                </div>
             </div>
             <hr>
-            <p class="copyright">&copy; 2026 Elixie, LLC. All rights reserved. ToolGuard is a product of Elixie, LLC.</p>
+            <p class="copyright">&copy; 2026 Elixie, LLC &mdash; California, USA &mdash; All rights reserved. ToolGuard is a product of Elixie, LLC.</p>
         </div>
     </footer>
 

--- a/privacy.html
+++ b/privacy.html
@@ -335,7 +335,12 @@
     <!-- Footer -->
     <footer class="footer">
         <div class="container">
-            <p class="copyright">&copy; 2026 Elixie, LLC. All rights reserved. ToolGuard is a product of Elixie, LLC.</p>
+            <p style="font-size:0.8125rem;text-align:center;margin-bottom:0.75rem;">
+                Questions? <a href="mailto:support@toolguard.ai" style="color:#9ca3af;text-decoration:underline;">support@toolguard.ai</a>
+                &nbsp;·&nbsp; <a href="/terms.html#cancellation" style="color:#9ca3af;text-decoration:underline;">Refund &amp; Cancellation Policy</a>
+                &nbsp;·&nbsp; <a href="/terms.html" style="color:#9ca3af;text-decoration:underline;">Terms of Service</a>
+            </p>
+            <p class="copyright">&copy; 2026 Elixie, LLC &mdash; California, USA &mdash; All rights reserved. ToolGuard is a product of Elixie, LLC.</p>
         </div>
     </footer>
 

--- a/terms.html
+++ b/terms.html
@@ -125,7 +125,7 @@
             <p><strong>3.4 Renewal.</strong> Subscriptions renew automatically at the end of each billing period unless canceled before the renewal date.</p>
         </div>
 
-        <div class="legal-section">
+        <div class="legal-section" id="cancellation">
             <h2>4. Cancellation and Refunds</h2>
             <p><strong>4.1 Cancellation.</strong> You may cancel your subscription at any time through your account settings or by contacting us at <a href="mailto:support@toolguard.ai">support@toolguard.ai</a>. Upon cancellation, you will retain access to the Service through the end of your current paid billing period. We do not charge cancellation fees.</p>
             <p><strong>4.2 Refunds — Annual plans.</strong> If you cancel an annual subscription within the first 30 days of the subscription start date, you may request a prorated refund for the unused portion of your term. After 30 days, annual subscriptions are non-refundable.</p>
@@ -248,7 +248,11 @@
     <!-- Footer -->
     <footer class="footer">
         <div class="container">
-            <p class="copyright">&copy; 2026 Elixie, LLC. All rights reserved. ToolGuard is a product of Elixie, LLC.</p>
+            <p style="font-size:0.8125rem;text-align:center;margin-bottom:0.75rem;">
+                Questions? <a href="mailto:support@toolguard.ai" style="color:#9ca3af;text-decoration:underline;">support@toolguard.ai</a>
+                &nbsp;·&nbsp; <a href="/privacy.html" style="color:#9ca3af;text-decoration:underline;">Privacy Policy</a>
+            </p>
+            <p class="copyright">&copy; 2026 Elixie, LLC &mdash; California, USA &mdash; All rights reserved. ToolGuard is a product of Elixie, LLC.</p>
         </div>
     </footer>
 


### PR DESCRIPTION
## Summary

Addresses two Stripe website compliance requirements before going live with Stripe:

- **[#334](https://github.com/toolguard/toolguard/issues/334)** — Add visible customer service contact info to website
- **[#335](https://github.com/toolguard/toolguard/issues/335)** — Surface refund and cancellation policy on pricing page

## Changes

### All pages (index.html, pricing.html, privacy.html, terms.html)
- Added **Support** footer column with `support@toolguard.ai`, Refund Policy link, Cancellation Policy link
- Updated footer copyright line to include "California, USA" (partial address for credibility)
- Updated footer grid from 4 to 5 columns

### index.html + pricing.html (below pricing cards)
- Added policy note: "All prices in USD · Annual plans refundable within 30 days. Monthly plans are non-refundable. Cancel anytime — no fees."
- Linked to full refund & cancellation policy in Terms
- Linked to `support@toolguard.ai`

### terms.html
- Added `id="cancellation"` anchor to Section 4 (Cancellation and Refunds) so deep-links work

## What's NOT covered here
- **#333** (explicit USD on price tags themselves) — separate small PR
- **#336** (full business address) — needs John to decide on address first
- **#337** (ToS checkbox at checkout) — blocked on #265
- **#338** (card logos at checkout) — blocked on #265
- **#339** (statement descriptor) — Stripe dashboard action, not code