### PR TITLE
Stripe compliance: display USD currency explicitly on pricing (#333)

### DIFF
--- a/index.html
+++ b/index.html
@@ -617,7 +617,7 @@
                 <div class="price-card featured">
                     <div class="badge-pop">Popular</div>
                     <div class="tier brand">Pro</div>
-                    <div class="price">$29 <span>/mo</span></div>
+                    <div class="price">$29 <span>/mo USD</span></div>
                     <div class="price-desc">Managed, multi-user</div>
                     <hr>
                     <ul>

--- a/pricing.html
+++ b/pricing.html
@@ -325,7 +325,7 @@
                     <div class="card-tier">Free</div>
                     <div class="card-price-row">
                         <span class="card-price">$0</span>
-                        <span class="card-price-period">/month</span>
+                        <span class="card-price-period">/month USD</span>
                     </div>
                     <p class="card-tagline">For individuals getting started with AI agent security.</p>
                     <hr class="card-divider">
@@ -356,11 +356,11 @@
                     <div class="card-tier brand">Pro</div>
                     <div class="card-price-row">
                         <span class="card-price" id="pro-price">$29</span>
-                        <span class="card-price-period">/month</span>
+                        <span class="card-price-period">/month USD</span>
                     </div>
                     <p class="card-price-alt">
-                        <span class="monthly-price">or <strong>$24/mo</strong> billed annually</span>
-                        <span class="annual-price">$24/mo — billed as <strong>$288/year</strong></span>
+                        <span class="monthly-price">or <strong>$24/mo USD</strong> billed annually</span>
+                        <span class="annual-price">$24/mo USD — billed as <strong>$288 USD/year</strong></span>
                     </p>
                     <p class="card-tagline">For developers and small teams who need unlimited power.</p>
                     <hr class="card-divider">


### PR DESCRIPTION
Adds explicit `USD` currency label to all prices on the pricing page and homepage, per Stripe's website checklist requirement.

**Changes:**
- `pricing.html`: `/month USD` on Free and Pro cards; annual alt text updated to include USD
- `index.html`: `/mo USD` on homepage Pro plan

The JS billing toggle only updates the price number (`$24`/`$29`), not the period span — USD remains visible in all toggle states.

Closes #333 in toolguard/toolguard.