### PR TITLE
Stripe compliance: add business address to website (#336)

### DIFF
--- a/index.html
+++ b/index.html
@@ -725,7 +725,7 @@
                 </div>
             </div>
             <hr>
-            <p class="copyright">&copy; 2026 Elixie, LLC. All rights reserved. ToolGuard is a product of Elixie, LLC.</p>
+            <p class="copyright">&copy; 2026 Elixie, LLC &mdash; 5044 Edinger Ave, Huntington Beach, CA 92649 &mdash; All rights reserved.</p>
         </div>
     </footer>
 

--- a/pricing.html
+++ b/pricing.html
@@ -540,7 +540,7 @@
                 </div>
             </div>
             <hr>
-            <p class="copyright">&copy; 2026 Elixie, LLC. All rights reserved. ToolGuard is a product of Elixie, LLC.</p>
+            <p class="copyright">&copy; 2026 Elixie, LLC &mdash; 5044 Edinger Ave, Huntington Beach, CA 92649 &mdash; All rights reserved.</p>
         </div>
     </footer>
 

--- a/privacy.html
+++ b/privacy.html
@@ -113,7 +113,8 @@
         <div class="legal-section">
             <h2>1. Who We Are</h2>
             <p>ToolGuard is a product of Elixie, LLC, a single-member limited liability company incorporated in the State of California. We operate globally through the internet.</p>
-            <p>Contact: <a href="mailto:support@toolguard.ai">support@toolguard.ai</a> | California, USA</p>
+            <p>Contact: <a href="mailto:support@toolguard.ai">support@toolguard.ai</a><br>
+            5044 Edinger Avenue, Huntington Beach, CA 92649, USA</p>
         </div>
 
         <div class="legal-section">
@@ -325,8 +326,9 @@
             <p>For questions, requests, or concerns about this Privacy Policy:</p>
             <p>
                 <strong>Elixie, LLC</strong><br>
-                <a href="mailto:support@toolguard.ai">support@toolguard.ai</a><br>
-                California, USA
+                5044 Edinger Avenue<br>
+                Huntington Beach, CA 92649<br>
+                <a href="mailto:support@toolguard.ai">support@toolguard.ai</a>
             </p>
             <p>ToolGuard is a product of Elixie, LLC.</p>
         </div>
@@ -335,7 +337,12 @@
     <!-- Footer -->
     <footer class="footer">
         <div class="container">
-            <p class="copyright">&copy; 2026 Elixie, LLC. All rights reserved. ToolGuard is a product of Elixie, LLC.</p>
+            <p style="font-size:0.8125rem;text-align:center;margin-bottom:0.75rem;">
+                Questions? <a href="mailto:support@toolguard.ai" style="color:#9ca3af;text-decoration:underline;">support@toolguard.ai</a>
+                &nbsp;·&nbsp; <a href="/terms.html#cancellation" style="color:#9ca3af;text-decoration:underline;">Refund &amp; Cancellation Policy</a>
+                &nbsp;·&nbsp; <a href="/terms.html" style="color:#9ca3af;text-decoration:underline;">Terms of Service</a>
+            </p>
+            <p class="copyright">&copy; 2026 Elixie, LLC &mdash; 5044 Edinger Ave, Huntington Beach, CA 92649 &mdash; All rights reserved.</p>
         </div>
     </footer>
 

--- a/terms.html
+++ b/terms.html
@@ -239,8 +239,9 @@
             <h3>Contact</h3>
             <p>For questions about these Terms, contact us at:</p>
             <p><strong>Elixie, LLC</strong><br>
-            <a href="mailto:support@toolguard.ai">support@toolguard.ai</a><br>
-            California, USA</p>
+            5044 Edinger Avenue<br>
+            Huntington Beach, CA 92649<br>
+            <a href="mailto:support@toolguard.ai">support@toolguard.ai</a></p>
             <p>ToolGuard is a product of Elixie, LLC.</p>
         </div>
     </div>
@@ -248,7 +249,11 @@
     <!-- Footer -->
     <footer class="footer">
         <div class="container">
-            <p class="copyright">&copy; 2026 Elixie, LLC. All rights reserved. ToolGuard is a product of Elixie, LLC.</p>
+            <p style="font-size:0.8125rem;text-align:center;margin-bottom:0.75rem;">
+                Questions? <a href="mailto:support@toolguard.ai" style="color:#9ca3af;text-decoration:underline;">support@toolguard.ai</a>
+                &nbsp;·&nbsp; <a href="/privacy.html" style="color:#9ca3af;text-decoration:underline;">Privacy Policy</a>
+            </p>
+            <p class="copyright">&copy; 2026 Elixie, LLC &mdash; 5044 Edinger Ave, Huntington Beach, CA 92649 &mdash; All rights reserved.</p>
         </div>
     </footer>
 


### PR DESCRIPTION
Adds Elixie, LLC's full business address to all pages:

**5044 Edinger Avenue, Huntington Beach, CA 92649**

**Pages updated:**
- `index.html` — footer copyright
- `pricing.html` — footer copyright
- `privacy.html` — Who We Are section, Contact section (section 14), footer
- `terms.html` — Contact section (section 18), footer

Closes #336 in toolguard/toolguard.