### PR TITLE
fix: nav Get Started button text contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,8 +51,8 @@
         .nav-links { display: none; align-items: center; gap: 2rem; }
         .nav-links a { font-size: 0.875rem; color: #4b5563; transition: color 0.2s; }
         .nav-links a:hover { color: #111827; }
-        .nav-cta { padding: 0.5rem 1rem; background: var(--brand-600); color: white; font-size: 0.875rem; font-weight: 500; border-radius: 0.5rem; transition: background 0.2s; }
-        .nav-cta:hover { background: var(--brand-700); color: white; }
+        .nav-cta { padding: 0.5rem 1rem; background: var(--brand-600); color: #ffffff !important; font-size: 0.875rem; font-weight: 600; border-radius: 0.5rem; transition: background 0.2s; }
+        .nav-cta:hover { background: var(--brand-700); color: #ffffff !important; }
         .nav-hamburger { display: block; padding: 0.5rem; background: none; border: none; cursor: pointer; color: #4b5563; }
         .nav-mobile { display: none; border-top: 1px solid #f3f4f6; background: white; padding: 1rem 1.5rem; }
         .nav-mobile.open { display: block; }

--- a/pricing.html
+++ b/pricing.html
@@ -52,8 +52,8 @@
         .nav-links a { font-size: 0.875rem; color: #4b5563; transition: color 0.2s; }
         .nav-links a:hover { color: #111827; }
         .nav-links a.active { color: var(--brand-600); font-weight: 600; }
-        .nav-cta { padding: 0.5rem 1rem; background: var(--brand-600); color: white; font-size: 0.875rem; font-weight: 500; border-radius: 0.5rem; transition: background 0.2s; }
-        .nav-cta:hover { background: var(--brand-700); color: white; }
+        .nav-cta { padding: 0.5rem 1rem; background: var(--brand-600); color: #ffffff !important; font-size: 0.875rem; font-weight: 600; border-radius: 0.5rem; transition: background 0.2s; }
+        .nav-cta:hover { background: var(--brand-700); color: #ffffff !important; }
         .nav-hamburger { display: block; padding: 0.5rem; background: none; border: none; cursor: pointer; color: #4b5563; }
         .nav-mobile { display: none; border-top: 1px solid #f3f4f6; background: white; padding: 1rem 1.5rem; }
         .nav-mobile.open { display: block; }

--- a/privacy.html
+++ b/privacy.html
@@ -35,8 +35,8 @@
         .nav-links { display: none; align-items: center; gap: 2rem; }
         .nav-links a { font-size: 0.875rem; color: #4b5563; transition: color 0.2s; }
         .nav-links a:hover { color: #111827; }
-        .nav-cta { padding: 0.5rem 1rem; background: var(--brand-600); color: white; font-size: 0.875rem; font-weight: 500; border-radius: 0.5rem; transition: background 0.2s; }
-        .nav-cta:hover { background: var(--brand-700); color: white; }
+        .nav-cta { padding: 0.5rem 1rem; background: var(--brand-600); color: #ffffff !important; font-size: 0.875rem; font-weight: 600; border-radius: 0.5rem; transition: background 0.2s; }
+        .nav-cta:hover { background: var(--brand-700); color: #ffffff !important; }
         @media (min-width: 768px) { .nav-links { display: flex; } }
 
         /* Content */

--- a/terms.html
+++ b/terms.html
@@ -35,8 +35,8 @@
         .nav-links { display: none; align-items: center; gap: 2rem; }
         .nav-links a { font-size: 0.875rem; color: #4b5563; transition: color 0.2s; }
         .nav-links a:hover { color: #111827; }
-        .nav-cta { padding: 0.5rem 1rem; background: var(--brand-600); color: white; font-size: 0.875rem; font-weight: 500; border-radius: 0.5rem; transition: background 0.2s; }
-        .nav-cta:hover { background: var(--brand-700); color: white; }
+        .nav-cta { padding: 0.5rem 1rem; background: var(--brand-600); color: #ffffff !important; font-size: 0.875rem; font-weight: 600; border-radius: 0.5rem; transition: background 0.2s; }
+        .nav-cta:hover { background: var(--brand-700); color: #ffffff !important; }
         @media (min-width: 768px) { .nav-links { display: flex; } }
 
         /* Content */


### PR DESCRIPTION
The nav `Get Started` button was showing dark text on blue background due to color inheritance from `.nav-links a { color: #4b5563 }`. Fixed with `color: #ffffff !important` on all 4 pages. Also bumped font-weight to 600 for clarity.