### PR TITLE
feat: add Stripe statement descriptor notice to pricing page

### DIFF
--- a/pricing.html
+++ b/pricing.html
@@ -391,6 +391,7 @@
                         </li>
                     </ul>
                     <a href="https://app.toolguard.ai" class="card-btn filled">Get Started</a>
+                    <p style="margin-top:0.625rem;font-size:0.75rem;color:#6b7280;text-align:center;">Charges will appear on your statement as TOOLGUARD</p>
                 </div>
 
                 <!-- Enterprise -->
@@ -435,6 +436,7 @@
                 </div>
 
             </div>
+            <p style="margin-top:1.5rem;font-size:0.8125rem;color:#9ca3af;text-align:center;">Paid plan charges will appear on your card statement as <strong>TOOLGUARD</strong>. Questions? Email <a href="mailto:support@toolguard.ai" style="color:var(--brand-600);">support@toolguard.ai</a>.</p>
         </div>
     </section>
 


### PR DESCRIPTION
Related to toolguard/toolguard#339

Adds notice that charges will appear as TOOLGUARD on card statements.

## Changes
- `pricing.html`: Added "Charges will appear on your statement as TOOLGUARD" notice directly below the Pro plan "Get Started" button
- `pricing.html`: Added a second note below the full pricing grid: "Paid plan charges will appear on your card statement as TOOLGUARD" with a link to support@toolguard.ai

These notices satisfy the Stripe compliance requirement that customers can recognize charges on their card statements.