### PR TITLE
fix: replace shim→connector and proxy→gateway in site copy (#48)

### DIFF
--- a/blog/valentine-sprint.html
+++ b/blog/valentine-sprint.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>The Valentine's Day Sprint — ToolGuard Blog</title>
-    <meta name="description" content="How we built ToolGuard in one intense day — from zero to security proxy in 24 hours.">
+    <meta name="description" content="How we built ToolGuard in one intense day — from zero to security gateway in 24 hours.">
     
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
@@ -13,7 +13,7 @@
     <!-- Open Graph Meta Tags -->
     <meta property="og:type" content="article">
     <meta property="og:title" content="The Valentine's Day Sprint — ToolGuard Blog">
-    <meta property="og:description" content="How we built ToolGuard in one intense day — from zero to security proxy in 24 hours.">
+    <meta property="og:description" content="How we built ToolGuard in one intense day — from zero to security gateway in 24 hours.">
     <meta property="og:image" content="/assets/og-image.png">
     <meta property="og:url" content="https://toolguard.ai/blog/valentine-sprint.html">
     
@@ -123,7 +123,7 @@
                 <span class="article-category">Behind the Scenes</span>
             </div>
             <h1 class="article-title">The Valentine's Day Sprint</h1>
-            <p class="article-subtitle">How we built ToolGuard in one intense day — from zero to security proxy in 24 hours.</p>
+            <p class="article-subtitle">How we built ToolGuard in one intense day — from zero to security gateway in 24 hours.</p>
             
             <div class="article-author">
                 <div class="author-avatar">👨‍💻</div>
@@ -157,12 +157,12 @@
 
             <h2>The Architecture</h2>
 
-            <p>The core insight was simple: we needed a security proxy that could sit between AI agents and MCP servers, providing a policy layer without breaking the existing ecosystem. The agent thinks it's talking to a regular MCP server, but in reality, every request flows through our security engine.</p>
+            <p>The core insight was simple: we needed a security gateway that could sit between AI agents and MCP servers, providing a policy layer without breaking the existing ecosystem. The agent thinks it's talking to a regular MCP server, but in reality, every request flows through our security engine.</p>
 
             <p>We settled on a three-component architecture:</p>
             <ul>
-                <li><strong>ToolGuard Proxy:</strong> The brain — handles credentials, policies, logging, and anomaly detection</li>
-                <li><strong>ToolGuard Shim:</strong> The adapter — presents as a standard MCP server to the AI agent</li>
+                <li><strong>ToolGuard Gateway:</strong> The brain — handles credentials, policies, logging, and anomaly detection</li>
+                <li><strong>ToolGuard Connector:</strong> The adapter — presents as a standard MCP server to the AI agent</li>
                 <li><strong>Plugin System:</strong> Service-specific adapters for Google Workspace, Slack, GitHub, etc.</li>
             </ul>
 
@@ -170,11 +170,11 @@
 
             <p>What followed was a blur of code, coffee, and constant iteration. We divided into three teams:</p>
 
-            <h3>Team Proxy (8 AM - 2 PM)</h3>
-            <p>Built the core proxy server with credential management and policy engine. The biggest challenge was designing a flexible policy language that could handle everything from rate limiting to content filtering without becoming too complex.</p>
+            <h3>Team Gateway (8 AM - 2 PM)</h3>
+            <p>Built the core gateway server with credential management and policy engine. The biggest challenge was designing a flexible policy language that could handle everything from rate limiting to content filtering without becoming too complex.</p>
 
-            <h3>Team Shim (2 PM - 8 PM)</h3>
-            <p>Created the MCP adapter that makes ToolGuard invisible to AI agents. This meant implementing the full MCP specification while transparently routing requests through our proxy. The devil was in the details — handling streaming responses, error propagation, and maintaining perfect protocol compatibility.</p>
+            <h3>Team Connector (2 PM - 8 PM)</h3>
+            <p>Created the MCP adapter that makes ToolGuard invisible to AI agents. This meant implementing the full MCP specification while transparently routing requests through our gateway. The devil was in the details — handling streaming responses, error propagation, and maintaining perfect protocol compatibility.</p>
 
             <h3>Team Dashboard (8 PM - 12 AM)</h3>
             <p>Built a web interface for configuration and monitoring. Real-time audit logs, policy management, and anomaly detection dashboards. We wanted something that would give security teams immediate visibility into AI behavior.</p>
@@ -190,7 +190,7 @@
             <p>As February 14th turned into February 15th, we pushed the first version to GitHub. 24 hours from whiteboard to working code. The initial release included:</p>
 
             <ul>
-                <li>Core proxy and shim components</li>
+                <li>Core gateway and connector components</li>
                 <li>Google Workspace plugin (Gmail, Calendar, Drive)</li>
                 <li>Policy engine with rate limiting and access controls</li>
                 <li>Audit logging and real-time monitoring</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Documentation — ToolGuard</title>
-    <meta name="description" content="ToolGuard documentation: Quick start guide, architecture overview, and CLI reference for the security proxy.">
+    <meta name="description" content="ToolGuard documentation: Quick start guide, architecture overview, and CLI reference for the security gateway.">
     
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
@@ -128,7 +128,7 @@
     <section class="hero">
         <div class="container">
             <h1>Documentation</h1>
-            <p>Everything you need to get started with ToolGuard — the security proxy for MCP servers</p>
+            <p>Everything you need to get started with ToolGuard — the security gateway for MCP servers</p>
         </div>
     </section>
 
@@ -174,7 +174,7 @@ npm run build</code></pre>
 }</code></pre>
 
                     <h3>Running ToolGuard</h3>
-                    <p>Start the ToolGuard proxy server:</p>
+                    <p>Start the ToolGuard gateway server:</p>
                     <pre><code># Start with default config
 toolguard proxy
 
@@ -194,7 +194,7 @@ toolguard proxy --verbose</code></pre>
 
                     <h3>Core Components</h3>
                     <ul>
-                        <li><strong>Proxy Server:</strong> The main entry point that intercepts all MCP requests</li>
+                        <li><strong>Gateway Server:</strong> The main entry point that intercepts all MCP requests</li>
                         <li><strong>Security Engine:</strong> Analyzes requests for potential security threats</li>
                         <li><strong>Credential Manager:</strong> Isolates and manages sensitive credentials</li>
                         <li><strong>Audit Logger:</strong> Records all activities for compliance and monitoring</li>
@@ -203,7 +203,7 @@ toolguard proxy --verbose</code></pre>
 
                     <h3>Request Flow</h3>
                     <ol>
-                        <li><strong>AI Agent</strong> sends request to ToolGuard proxy</li>
+                        <li><strong>AI Agent</strong> sends request to ToolGuard gateway</li>
                         <li><strong>Authentication</strong> validates the agent's identity</li>
                         <li><strong>Policy Check</strong> ensures request complies with security rules</li>
                         <li><strong>Threat Analysis</strong> scans for potential security risks</li>
@@ -227,10 +227,10 @@ toolguard proxy --verbose</code></pre>
                 <!-- CLI Reference -->
                 <div class="section">
                     <h2>⚙️ CLI Reference</h2>
-                    <p>ToolGuard provides three main commands to manage your security proxy:</p>
+                    <p>ToolGuard provides three main commands to manage your security gateway:</p>
 
                     <h3>proxy</h3>
-                    <p>Starts the main ToolGuard proxy server.</p>
+                    <p>Starts the main ToolGuard gateway server.</p>
                     <pre><code>toolguard proxy [options]
 
 Options:
@@ -247,13 +247,13 @@ Examples:
   toolguard proxy --daemon --pid-file /var/run/toolguard.pid</code></pre>
 
                     <h3>shim</h3>
-                    <p>Creates a transparent shim for existing MCP installations.</p>
+                    <p>Creates a transparent connector for existing MCP installations.</p>
                     <pre><code>toolguard shim [options] &lt;mcp-server-command&gt;
 
 Options:
   --config, -c     Path to configuration file
-  --output, -o     Output shim script path
-  --template, -t   Shim template to use (bash, powershell, docker)
+  --output, -o     Output connector script path
+  --template, -t   Connector template to use (bash, powershell, docker)
 
 Examples:
   toolguard shim "npx @modelcontextprotocol/server-filesystem /data"

--- a/dpa.html
+++ b/dpa.html
@@ -123,7 +123,7 @@
                 <li><strong>"Sub-processor"</strong> means any third party engaged by ToolGuard to process personal data in connection with delivering the service.</li>
                 <li><strong>"GDPR"</strong> means Regulation (EU) 2016/679 of the European Parliament and of the Council (General Data Protection Regulation).</li>
                 <li><strong>"SCCs"</strong> means the Standard Contractual Clauses for the transfer of personal data to third countries pursuant to GDPR, as issued by the European Commission.</li>
-                <li><strong>"Service"</strong> means the ToolGuard security proxy platform, including the hosted proxy, shim, dashboard, and related services offered at toolguard.ai.</li>
+                <li><strong>"Service"</strong> means the ToolGuard security gateway platform, including the hosted gateway, connector, dashboard, and related services offered at toolguard.ai.</li>
             </ul>
         </div>
 
@@ -132,7 +132,7 @@
             <p>ToolGuard processes personal data solely to the extent necessary to provide the Service. The categories of personal data processed include:</p>
             <ul>
                 <li><strong>Account data:</strong> Email addresses used to create and manage ToolGuard accounts (including OAuth-linked email addresses from Google and GitHub).</li>
-                <li><strong>Audit logs:</strong> Records of tool calls made through the ToolGuard proxy, including timestamps, tool names, request metadata, and policy decisions. These logs may contain personal data passed through connected MCP servers (e.g., email subjects, contact names) depending on the services the Controller has connected.</li>
+                <li><strong>Audit logs:</strong> Records of tool calls made through the ToolGuard gateway, including timestamps, tool names, request metadata, and policy decisions. These logs may contain personal data passed through connected MCP servers (e.g., email subjects, contact names) depending on the services the Controller has connected.</li>
                 <li><strong>Usage data:</strong> Service interaction data, including API request counts, feature usage patterns, and error logs used for diagnostics and service improvement.</li>
                 <li><strong>Billing data:</strong> Name and email address associated with payment records, processed via Stripe. Full payment card data is handled exclusively by Stripe and is not stored by ToolGuard.</li>
                 <li><strong>Authentication tokens:</strong> Encrypted OAuth tokens and API credentials stored in the ToolGuard vault for connected services. These are stored in encrypted form and are not accessible in plaintext by ToolGuard staff.</li>
@@ -223,7 +223,7 @@
             <h3>6.1 Encryption</h3>
             <ul>
                 <li><strong>At rest:</strong> All credentials and sensitive vault data are encrypted using AES-256-GCM. Database-level encryption is applied via Neon's encrypted storage.</li>
-                <li><strong>In transit:</strong> All communications between users, the ToolGuard proxy, and connected services are encrypted using TLS 1.2 or higher.</li>
+                <li><strong>In transit:</strong> All communications between users, the ToolGuard gateway, and connected services are encrypted using TLS 1.2 or higher.</li>
             </ul>
 
             <h3>6.2 Access Controls</h3>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ToolGuard — Security Proxy for MCP Servers</title>
+    <title>ToolGuard — Security Gateway for MCP Servers</title>
     <meta name="description" content="ToolGuard securely connects AI agents to your services — Gmail, GitHub, and more — with credential isolation, policy enforcement, and a full audit log.">
     
     <!-- Favicon -->
@@ -12,15 +12,15 @@
     
     <!-- Open Graph Meta Tags -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="ToolGuard — Security Proxy for MCP Servers">
-    <meta property="og:description" content="Open-source security proxy for AI agents. Credential isolation, policy enforcement, audit logging, and anomaly detection for MCP servers.">
+    <meta property="og:title" content="ToolGuard — Security Gateway for MCP Servers">
+    <meta property="og:description" content="Open-source security gateway for AI agents. Credential isolation, policy enforcement, audit logging, and anomaly detection for MCP servers.">
     <meta property="og:image" content="/assets/og-image.svg">
     <meta property="og:url" content="https://toolguard.ai">
     
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="ToolGuard — Security Proxy for MCP Servers">
-    <meta name="twitter:description" content="Open-source security proxy for AI agents. Credential isolation, policy enforcement, audit logging, and anomaly detection for MCP servers.">
+    <meta name="twitter:title" content="ToolGuard — Security Gateway for MCP Servers">
+    <meta name="twitter:description" content="Open-source security gateway for AI agents. Credential isolation, policy enforcement, audit logging, and anomaly detection for MCP servers.">
     <meta name="twitter:image" content="/assets/og-image.svg">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -416,7 +416,7 @@
             <span class="hero-badge-dot"></span>
             Open Source
         </div>
-        <h1>Security proxy for <span class="accent">AI agents</span> accessing your tools</h1>
+        <h1>Security gateway for <span class="accent">AI agents</span> accessing your tools</h1>
         <p class="subtitle">Give Claude or Cursor access to Gmail, GitHub, and more — without handing over your credentials. ToolGuard isolates secrets, enforces policy, and logs every tool call your AI makes.</p>
         <div class="cta-row">
             <a href="https://app.toolguard.ai" class="btn-primary">Get Started Free</a>
@@ -444,14 +444,14 @@
                 <div class="arch-arrow desktop-horizontal">→</div>
                 <div class="arch-node shim animate">
                     <div class="emoji">🛡️</div>
-                    <div class="name">ToolGuard Shim</div>
+                    <div class="name">ToolGuard Connector</div>
                     <div class="desc">Local MCP adapter</div>
                 </div>
                 <div class="arch-arrow mobile-vertical">↓</div>
                 <div class="arch-arrow desktop-horizontal">→</div>
                 <div class="arch-node proxy animate">
                     <div class="emoji">🔒</div>
-                    <div class="name">ToolGuard Proxy</div>
+                    <div class="name">ToolGuard Gateway</div>
                     <div class="desc">Policy · Review · Audit</div>
                 </div>
                 <div class="arch-arrow mobile-vertical">↓</div>
@@ -481,7 +481,7 @@
                 <div class="hiw-step">
                     <div class="hiw-step-num">2</div>
                     <h3>Your AI calls tools</h3>
-                    <p>AI agents access your services through ToolGuard. They get results, not credentials. Every call goes through the proxy.</p>
+                    <p>AI agents access your services through ToolGuard. They get results, not credentials. Every call goes through the gateway.</p>
                 </div>
                 <div class="hiw-connector">→</div>
                 <div class="hiw-step">
@@ -544,14 +544,14 @@
                     <div class="comparison-header">
                         <div class="comparison-icon safe">🛡️</div>
                         <h3>With ToolGuard</h3>
-                        <p class="comparison-label">Secure Proxy Access</p>
+                        <p class="comparison-label">Secure Gateway Access</p>
                     </div>
                     <div class="benefit-list">
                         <div class="benefit-item">
                             <div class="benefit-icon">🔐</div>
                             <div>
                                 <strong>Credentials Isolated</strong>
-                                <p>API keys safely stored in the proxy. AI agent only has a simple token with limited scope.</p>
+                                <p>API keys safely stored in the gateway. AI agent only has a simple token with limited scope.</p>
                             </div>
                         </div>
                         <div class="benefit-item">
@@ -590,12 +590,12 @@
                 <div class="feature-card">
                     <div class="feature-icon">🔐</div>
                     <h3>Credential Isolation</h3>
-                    <p>API keys and OAuth tokens never leave the proxy. Your AI agent authenticates with a simple token — ToolGuard handles the rest.</p>
+                    <p>API keys and OAuth tokens never leave the gateway. Your AI agent authenticates with a simple token — ToolGuard handles the rest.</p>
                 </div>
                 <div class="feature-card">
                     <div class="feature-icon">📋</div>
                     <h3>Policy Engine</h3>
-                    <p>Define what your AI can and can't do. Rate limits, tool access controls, sensitivity levels, contact filters — all enforced at the proxy.</p>
+                    <p>Define what your AI can and can't do. Rate limits, tool access controls, sensitivity levels, contact filters — all enforced at the gateway.</p>
                 </div>
                 <div class="feature-card">
                     <div class="feature-icon">👁️</div>
@@ -641,8 +641,8 @@
                 </div>
                 <div class="step">
                     <div class="step-num">3</div>
-                    <h3>Point your AI at the shim</h3>
-                    <p>Configure your AI agent to use the ToolGuard shim as its MCP server. Everything flows through the proxy.</p>
+                    <h3>Point your AI at the connector</h3>
+                    <p>Configure your AI agent to use the ToolGuard connector as its MCP server. Everything flows through the gateway.</p>
                     <code>$ toolguard shim --proxy https://...</code>
                 </div>
             </div>
@@ -671,7 +671,7 @@
                         <span class="blog-category">Behind the Scenes</span>
                     </div>
                     <h3><a href="/blog/valentine-sprint.html">The Valentine's Day Sprint</a></h3>
-                    <p>How we built ToolGuard in one intense day — from zero to security proxy in 24 hours. A tale of caffeine, code, and the power of focused execution.</p>
+                    <p>How we built ToolGuard in one intense day — from zero to security gateway in 24 hours. A tale of caffeine, code, and the power of focused execution.</p>
                     <div class="blog-author">
                         <div class="author-avatar">👨‍💻</div>
                         <div class="author-info">

--- a/pricing.html
+++ b/pricing.html
@@ -321,7 +321,7 @@
     <!-- Page Header -->
     <header class="page-header">
         <h1>Simple, transparent pricing</h1>
-        <p>Start free, no credit card required. Upgrade when you need more power. All plans include the core ToolGuard security proxy.</p>
+        <p>Start free, no credit card required. Upgrade when you need more power. All plans include the core ToolGuard security gateway.</p>
         <p class="note">⚠️ Pricing shown is illustrative — final pricing is pending confirmation. See <a href="https://github.com/toolguard/toolguard/issues/248" style="color:rgba(255,255,255,0.85);text-decoration:underline;">#248</a>.</p>
 
         <!-- Annual / Monthly toggle -->

--- a/privacy.html
+++ b/privacy.html
@@ -135,11 +135,11 @@
             </ul>
 
             <h3>2.3 Information we do NOT store</h3>
-            <p>ToolGuard acts as a real-time security proxy. The following data passes through our Service but is not stored on our servers:</p>
+            <p>ToolGuard acts as a real-time security gateway. The following data passes through our Service but is not stored on our servers:</p>
             <ul>
                 <li>Your API keys, OAuth tokens, or credentials for third-party services (these are held in encrypted, zero-knowledge storage and decrypted only in memory during processing).</li>
                 <li>The content of emails, documents, or other data retrieved from third-party services on your behalf.</li>
-                <li>Individual tool call inputs and outputs processed through the proxy.</li>
+                <li>Individual tool call inputs and outputs processed through the gateway.</li>
             </ul>
             <p>We are designed so that we cannot read your credentials or the content of what you retrieve. Our role is to proxy requests securely, not to read or retain your data.</p>
         </div>

--- a/terms.html
+++ b/terms.html
@@ -107,7 +107,7 @@
 
         <div class="legal-section">
             <h2>1. The Service</h2>
-            <p>ToolGuard is a security proxy for Model Context Protocol (MCP) servers that provides authenticated, policy-controlled access to external services and APIs. We provide the Service on a subscription basis through our website at toolguard.ai.</p>
+            <p>ToolGuard is a security gateway for Model Context Protocol (MCP) servers that provides authenticated, policy-controlled access to external services and APIs. We provide the Service on a subscription basis through our website at toolguard.ai.</p>
         </div>
 
         <div class="legal-section">


### PR DESCRIPTION
Closes #48

Replaces outdated terminology throughout the site:
- "shim" → "connector"
- "proxy" → "gateway" (ToolGuard component references only)

## What was changed

**7 files changed across all HTML files.**

### Replacements made:
- `ToolGuard Shim` → `ToolGuard Connector` (component name in arch diagrams, blog, docs)
- `ToolGuard Proxy` → `ToolGuard Gateway` (component name in arch diagrams, blog, docs)
- `Security Proxy` → `Security Gateway` (titles, meta, og/twitter tags, hero headlines)
- `security proxy` → `security gateway` (feature descriptions, legal definitions)

### Intentionally preserved:
- CSS class names (`.arch-node.shim`, `.arch-node.proxy`) — internal identifiers
- CLI command examples (`toolguard proxy`, `toolguard shim`) — actual commands users run
- `terms.html` §6: "acts as a proxy to third-party services" — generic legal/routing verb
- `privacy.html`: "Our role is to proxy requests securely" — generic verb in legal context